### PR TITLE
Implement gerrit scm

### DIFF
--- a/cmd/other.go
+++ b/cmd/other.go
@@ -37,11 +37,13 @@ func getToken(flag *flag.FlagSet) (string, error) {
 			token = ght
 		} else if ght := os.Getenv("BITBUCKET_CLOUD_WORKSPACE_TOKEN"); ght != "" {
 			token = ght
+		} else if ght := os.Getenv("GERRIT_TOKEN"); ght != "" {
+			token = ght
 		}
 	}
 
 	if token == "" {
-		return "", errors.New("either the --token flag or the GITHUB_TOKEN/GITLAB_TOKEN/GITEA_TOKEN/BITBUCKET_SERVER_TOKEN/BITBUCKET_CLOUD_APP_PASSWORD/BITBUCKET_CLOUD_WORKSPACE_TOKEN environment variable has to be set")
+		return "", errors.New("either the --token flag or the GITHUB_TOKEN/GITLAB_TOKEN/GITEA_TOKEN/BITBUCKET_SERVER_TOKEN/BITBUCKET_CLOUD_APP_PASSWORD/BITBUCKET_CLOUD_WORKSPACE_TOKEN/GERRIT_TOKEN environment variable has to be set")
 	}
 
 	return token, nil

--- a/cmd/platform.go
+++ b/cmd/platform.go
@@ -395,7 +395,7 @@ func createBitbucketServerClient(flag *flag.FlagSet, verifyFlags bool) (multigit
 	return vc, nil
 }
 
-func createGerritClient(flag *flag.FlagSet, verifyFlags bool) (multigitter.VersionController, error) {
+func createGerritClient(flag *flag.FlagSet, _ bool) (multigitter.VersionController, error) {
 	username, _ := flag.GetString("username")
 	if username == "" {
 		return nil, errors.New("no username set")

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23.3
 
 require (
 	code.gitea.io/sdk/gitea v0.21.0
-	github.com/andygrunwald/go-gerrit v1.0.0
+	github.com/andygrunwald/go-gerrit v1.1.0
 	github.com/eiannone/keyboard v0.0.0-20220611211555-0d226195f203
 	github.com/gfleury/go-bitbucket-v1 v0.0.0-20240917142304-df385efaac68
 	github.com/go-git/go-git/v5 v5.16.2

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23.3
 
 require (
 	code.gitea.io/sdk/gitea v0.21.0
+	github.com/andygrunwald/go-gerrit v1.0.0
 	github.com/eiannone/keyboard v0.0.0-20220611211555-0d226195f203
 	github.com/gfleury/go-bitbucket-v1 v0.0.0-20240917142304-df385efaac68
 	github.com/go-git/go-git/v5 v5.16.2

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/ProtonMail/go-crypto v1.1.6 h1:ZcV+Ropw6Qn0AX9brlQLAUXfqLBc7Bl+f/DmNx
 github.com/ProtonMail/go-crypto v1.1.6/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
 github.com/andygrunwald/go-gerrit v1.0.0 h1:TrRGbso70QjJcXPC4kkLiKQrAfCBoBV+cBs7NrJxeno=
 github.com/andygrunwald/go-gerrit v1.0.0/go.mod h1:SeP12EkHZxEVjuJ2HZET304NBtHGG2X6w2Gzd0QXAZw=
+github.com/andygrunwald/go-gerrit v1.1.0 h1:+svCkLj2kkrClYWZhynSCOizAoCjw8uZJhRs+x3nbAs=
+github.com/andygrunwald/go-gerrit v1.1.0/go.mod h1:SeP12EkHZxEVjuJ2HZET304NBtHGG2X6w2Gzd0QXAZw=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.1.6 h1:ZcV+Ropw6Qn0AX9brlQLAUXfqLBc7Bl+f/DmNxpLfdw=
 github.com/ProtonMail/go-crypto v1.1.6/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
+github.com/andygrunwald/go-gerrit v1.0.0 h1:TrRGbso70QjJcXPC4kkLiKQrAfCBoBV+cBs7NrJxeno=
+github.com/andygrunwald/go-gerrit v1.0.0/go.mod h1:SeP12EkHZxEVjuJ2HZET304NBtHGG2X6w2Gzd0QXAZw=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=

--- a/internal/git/cmdgit/git.go
+++ b/internal/git/cmdgit/git.go
@@ -140,12 +140,16 @@ func (g *Git) BranchExist(remoteName, branchName string) (bool, error) {
 }
 
 // Push the committed changes to the remote
-func (g *Git) Push(ctx context.Context, remoteName string, force bool) error {
+func (g *Git) Push(ctx context.Context, remoteName, remoteReference string, force bool) error {
 	args := []string{"push", "--no-verify", remoteName}
 	if force {
 		args = append(args, "--force")
 	}
-	args = append(args, "HEAD")
+	refSpec := "HEAD"
+	if remoteReference != "" {
+		refSpec = refSpec + ":" + remoteReference
+	}
+	args = append(args, refSpec)
 
 	cmd := exec.CommandContext(ctx, "git", args...)
 	_, err := g.run(cmd)

--- a/internal/multigitter/shared.go
+++ b/internal/multigitter/shared.go
@@ -32,7 +32,7 @@ type Git interface {
 	Changes() (bool, error)
 	Commit(commitAuthor *git.CommitAuthor, commitMessage string) error
 	BranchExist(remoteName, branchName string) (bool, error)
-	Push(ctx context.Context, remoteName string, force bool) error
+	Push(ctx context.Context, remoteName, remoteReference string, force bool) error
 	AddRemote(name, url string) error
 }
 

--- a/internal/scm/gerrit/change.go
+++ b/internal/scm/gerrit/change.go
@@ -15,7 +15,7 @@ type change struct {
 	project  string
 	branch   string
 	number   int
-	changeId string
+	changeID string
 	status   scm.PullRequestStatus
 	webURL   string
 }
@@ -32,7 +32,7 @@ func (r change) URL() string {
 	return r.webURL
 }
 
-func convertChange(changeInfo gogerrit.ChangeInfo, baseUrl string) scm.PullRequest {
+func convertChange(changeInfo gogerrit.ChangeInfo, baseURL string) scm.PullRequest {
 	status := scm.PullRequestStatusUnknown
 
 	if changeInfo.Submittable {
@@ -53,8 +53,8 @@ func convertChange(changeInfo gogerrit.ChangeInfo, baseUrl string) scm.PullReque
 		project:  changeInfo.Project,
 		branch:   changeInfo.Branch,
 		number:   changeInfo.Number,
-		changeId: changeInfo.ChangeID,
+		changeID: changeInfo.ChangeID,
 		status:   status,
-		webURL:   strings.Join([]string{baseUrl, "c", changeInfo.Project, "+", strconv.Itoa(changeInfo.Number)}, "/"),
+		webURL:   strings.Join([]string{baseURL, "c", changeInfo.Project, "+", strconv.Itoa(changeInfo.Number)}, "/"),
 	}
 }

--- a/internal/scm/gerrit/change.go
+++ b/internal/scm/gerrit/change.go
@@ -1,0 +1,60 @@
+package gerrit
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/lindell/multi-gitter/internal/scm"
+
+	gogerrit "github.com/andygrunwald/go-gerrit"
+)
+
+type change struct {
+	id       string
+	project  string
+	branch   string
+	number   int
+	changeId string
+	status   scm.PullRequestStatus
+	webURL   string
+}
+
+func (r change) String() string {
+	return fmt.Sprintf("%d: %s", r.number, r.project)
+}
+
+func (r change) Status() scm.PullRequestStatus {
+	return r.status
+}
+
+func (r change) URL() string {
+	return r.webURL
+}
+
+func convertChange(changeInfo gogerrit.ChangeInfo, baseUrl string) scm.PullRequest {
+	status := scm.PullRequestStatusUnknown
+
+	if changeInfo.Submittable {
+		status = scm.PullRequestStatusSuccess
+	} else {
+		switch changeInfo.Status {
+		case "NEW":
+			status = scm.PullRequestStatusPending
+		case "MERGED":
+			status = scm.PullRequestStatusMerged
+		case "ABANDONED":
+			status = scm.PullRequestStatusClosed
+		}
+	}
+
+	return change{
+		id:       changeInfo.ID,
+		project:  changeInfo.Project,
+		branch:   changeInfo.Branch,
+		number:   changeInfo.Number,
+		changeId: changeInfo.ChangeID,
+		status:   status,
+		webURL:   strings.Join([]string{baseUrl, "c", changeInfo.Project, "+", strconv.Itoa(changeInfo.Number)}, "/"),
+	}
+}

--- a/internal/scm/gerrit/change.go
+++ b/internal/scm/gerrit/change.go
@@ -2,9 +2,6 @@ package gerrit
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
-
 	"github.com/lindell/multi-gitter/internal/scm"
 
 	gogerrit "github.com/andygrunwald/go-gerrit"
@@ -55,6 +52,6 @@ func convertChange(changeInfo gogerrit.ChangeInfo, baseURL string) scm.PullReque
 		number:   changeInfo.Number,
 		changeID: changeInfo.ChangeID,
 		status:   status,
-		webURL:   strings.Join([]string{baseURL, "c", changeInfo.Project, "+", strconv.Itoa(changeInfo.Number)}, "/"),
+		webURL:   fmt.Sprintf("%s/c/%s/+/%d", baseURL, changeInfo.Project, changeInfo.Number),
 	}
 }

--- a/internal/scm/gerrit/gerrit.go
+++ b/internal/scm/gerrit/gerrit.go
@@ -33,7 +33,7 @@ type Gerrit struct {
 }
 
 func New(username, token, baseURL, repoSearch string) (*Gerrit, error) {
-	ctx := context.Background()
+	ctx := context.Background() // cancellation won't happen in our case (only used by go-gerrit if you inject username and token directly within baseURL)
 	client, err := gogerrit.NewClient(ctx, baseURL, &http.Client{
 		Transport: internalHTTP.LoggingRoundTripper{},
 	})

--- a/internal/scm/gerrit/gerrit.go
+++ b/internal/scm/gerrit/gerrit.go
@@ -143,7 +143,7 @@ func (g Gerrit) GetPullRequests(ctx context.Context, branchName string) ([]scm.P
 		}
 
 		moreChanges := false
-		for _, change := range *changes {
+		for _, change := range changes {
 			if _, ok := projectNames[change.Project]; ok {
 				prs = append(prs, convertChange(change, g.baseURL))
 			}
@@ -172,13 +172,13 @@ func (g Gerrit) GetOpenPullRequest(ctx context.Context, repo scm.Repository, bra
 		return nil, err
 	}
 
-	if len(*changes) == 0 {
+	if len(changes) == 0 {
 		return nil, nil
-	} else if len(*changes) > 1 {
+	} else if len(changes) > 1 {
 		return nil, errors.New("More than one open change for branch " + branchName + " in project " + repo.FullName())
 	}
 
-	return convertChange((*changes)[0], g.baseURL), nil
+	return convertChange(changes[0], g.baseURL), nil
 }
 
 func (g Gerrit) MergePullRequest(ctx context.Context, pr scm.PullRequest) error {
@@ -213,7 +213,7 @@ func (g Gerrit) getChange(ctx context.Context, repo scm.Repository, branchName s
 	return pr, nil
 }
 
-func (g Gerrit) queryChanges(ctx context.Context, branchName string, filters []string, start int, limit int) (*[]gogerrit.ChangeInfo, error) {
+func (g Gerrit) queryChanges(ctx context.Context, branchName string, filters []string, start int, limit int) ([]gogerrit.ChangeInfo, error) {
 	defaultFilters := []string{
 		"footer:" + FooterBranch + "=" + branchName,
 	}
@@ -235,7 +235,7 @@ func (g Gerrit) queryChanges(ctx context.Context, branchName string, filters []s
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to query changes: '%s'", filters)
 	}
-	return changes, nil
+	return *changes, nil
 }
 
 func (g Gerrit) EnhanceCommit(ctx context.Context, repo scm.Repository, branchName string, commitMessage string) (string, error) {

--- a/internal/scm/gerrit/gerrit.go
+++ b/internal/scm/gerrit/gerrit.go
@@ -1,0 +1,251 @@
+package gerrit
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+	"maps"
+	"net/url"
+	"os"
+	"os/user"
+	"slices"
+	"strings"
+	"time"
+
+	gogerrit "github.com/andygrunwald/go-gerrit"
+	"github.com/lindell/multi-gitter/internal/scm"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+const FooterBranch = "MultiGitter-Branch"
+const FooterChangeId = "Change-Id"
+
+type Gerrit struct {
+	client     GoGerritClient
+	baseUrl    string
+	username   string
+	token      string
+	repoSearch string
+}
+
+func New(username, token, baseURL, repoSearch string) (*Gerrit, error) {
+	ctx := context.Background()
+	client, err := gogerrit.NewClient(ctx, baseURL, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create gerrit client")
+	}
+
+	client.Authentication.SetBasicAuth(username, token)
+
+	return &Gerrit{
+		client: goGerritClient{
+			client: client,
+		},
+		baseUrl:    baseURL,
+		username:   username,
+		token:      token,
+		repoSearch: repoSearch,
+	}, nil
+}
+
+func (g Gerrit) GetRepositories(ctx context.Context) ([]scm.Repository, error) {
+	opt := &gogerrit.ProjectOptions{
+		Description: true,
+		Regex:       g.repoSearch,
+		Type:        "CODE",
+		ProjectBaseOptions: gogerrit.ProjectBaseOptions{
+			Limit: 2500, // Maybe we should make this configurable
+		},
+	}
+	projects, _, err := g.client.ListProjects(ctx, opt)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list projects")
+	}
+
+	repos := make([]scm.Repository, 0)
+	for _, name := range slices.Sorted(maps.Keys(*projects)) {
+		project := (*projects)[name]
+		if project.State != "ACTIVE" {
+			log.Debug("Skipping repository since state is not ACTIVE")
+			continue
+		}
+
+		repo, err := g.convertRepo(name)
+		if err != nil {
+			return nil, err
+		}
+
+		repos = append(repos, repo)
+	}
+
+	return repos, nil
+}
+
+func (g Gerrit) convertRepo(name string) (repository, error) {
+	// Note: maybe we should support cloning via ssh
+	u, err := url.Parse(g.baseUrl)
+	if err != nil {
+		return repository{}, err
+	}
+	u.User = url.UserPassword(g.username, g.token)
+	u.Path = "/a/" + name
+	repoUrl := u.String()
+
+	return repository{
+		url:           repoUrl,
+		name:          name,
+		defaultBranch: "master", // Some projects might have a different default branch
+	}, nil
+}
+
+func (g Gerrit) CreatePullRequest(ctx context.Context, repo scm.Repository, prRepo scm.Repository, newPR scm.NewPullRequest) (scm.PullRequest, error) {
+	// In Gerrit context, pushing a commit to refs/for/<base_branch> is enough to create automatically a change.
+	// So here, we are just "fetching" the change related to current branch (Head of PR)
+	// Not yet implemented: reviewers, team reviewers, assignees, draft, labels
+
+	return g.getChange(ctx, repo, newPR.Head)
+}
+
+func (g Gerrit) UpdatePullRequest(ctx context.Context, repo scm.Repository, pullReq scm.PullRequest, updatedPR scm.NewPullRequest) (scm.PullRequest, error) {
+	// In Gerrit context, pushing a commit to refs/for/<base_branch> is enough to create automatically a change.
+	// So here, we are just "fetching" the change related
+	// Not yet implemented: reviewers, team reviewers, assignees, draft, labels
+
+	return g.getChange(ctx, repo, updatedPR.Head)
+}
+
+func (g Gerrit) GetPullRequests(ctx context.Context, branchName string) ([]scm.PullRequest, error) {
+	repositories, err := g.GetRepositories(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var prs []scm.PullRequest
+	for _, repo := range repositories {
+		changes, err := g.queryChanges(ctx, repo, branchName, []string{})
+		if err != nil {
+			return nil, err
+		}
+		for _, change := range *changes {
+			prs = append(prs, convertChange(change, g.baseUrl))
+		}
+	}
+
+	return prs, err
+}
+
+func (g Gerrit) GetOpenPullRequest(ctx context.Context, repo scm.Repository, branchName string) (scm.PullRequest, error) {
+	changes, err := g.queryChanges(ctx, repo, branchName, []string{
+		"is:open",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(*changes) == 0 {
+		return nil, nil
+	} else if len(*changes) > 1 {
+		return nil, errors.New("More than one open change for branch " + branchName + " in project " + repo.FullName())
+	}
+
+	return convertChange((*changes)[0], g.baseUrl), nil
+}
+
+func (g Gerrit) MergePullRequest(ctx context.Context, pr scm.PullRequest) error {
+	change := pr.(change)
+
+	_, _, err := g.client.SubmitChange(ctx, change.id, &gogerrit.SubmitInput{})
+
+	return err
+}
+
+func (g Gerrit) ClosePullRequest(ctx context.Context, pr scm.PullRequest) error {
+	change := pr.(change)
+
+	_, _, err := g.client.AbandonChange(ctx, change.id, &gogerrit.AbandonInput{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (Gerrit) ForkRepository(ctx context.Context, repo scm.Repository, newOwner string) (scm.Repository, error) {
+	return nil, errors.New("Forking repositories is not supported in Gerrit")
+}
+
+func (g Gerrit) getChange(ctx context.Context, repo scm.Repository, branchName string) (scm.PullRequest, error) {
+	pr, err := g.GetOpenPullRequest(ctx, repo, branchName)
+	if err != nil {
+		return nil, err
+	} else if pr == nil {
+		return nil, errors.Errorf("Unable to find any open change related to branch %s in project %s", branchName, repo.FullName())
+	}
+	return pr, nil
+}
+
+func (g Gerrit) queryChanges(ctx context.Context, repo scm.Repository, branchName string, filters []string) (*[]gogerrit.ChangeInfo, error) {
+	defaultFilters := []string{
+		"project:" + repo.FullName(),
+		"footer:" + FooterBranch + "=" + branchName,
+	}
+	query := strings.Join(append(defaultFilters, filters...), "+")
+
+	opt := &gogerrit.QueryChangeOptions{
+		QueryOptions: gogerrit.QueryOptions{
+			Query: []string{query},
+		},
+		ChangeOptions: gogerrit.ChangeOptions{
+			AdditionalFields: []string{
+				"SUBMITTABLE",
+			},
+		},
+	}
+	changes, _, err := g.client.QueryChanges(ctx, opt)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to query changes: '%s'", filters)
+	}
+	return changes, nil
+}
+
+func (g Gerrit) EnhanceCommit(ctx context.Context, repo scm.Repository, branchName string, commitMessage string) (string, error) {
+	pr, err := g.GetOpenPullRequest(ctx, repo, branchName)
+	if err != nil {
+		return commitMessage, err
+	}
+
+	changeId := ""
+	if pr != nil {
+		changeId = pr.(change).changeId
+	} else {
+		changeId = generateChangeId(commitMessage)
+	}
+	message := commitMessage
+	message = message + "\n\n" + FooterBranch + ": " + branchName
+	message = message + "\n" + FooterChangeId + ": " + changeId
+	return message, nil
+}
+
+func (g Gerrit) FeatureBranchExist(ctx context.Context, repo scm.Repository, branchName string) (bool, error) {
+	pr, err := g.GetOpenPullRequest(ctx, repo, branchName)
+	return pr != nil, err
+}
+
+func (g Gerrit) RemoteReference(baseBranch string, featureBranch string, skipPullRequest bool, pushOnly bool) string {
+	if !skipPullRequest && !pushOnly {
+		return "refs/for/" + baseBranch
+	}
+	return "refs/heads/" + featureBranch
+}
+
+func generateChangeId(commitMessage string) string {
+	h := sha1.New()
+	hostname, _ := os.Hostname()
+	whoami, _ := user.Current()
+	h.Write([]byte(hostname))
+	h.Write([]byte(whoami.Username))
+	h.Write([]byte(time.Now().String()))
+	h.Write([]byte(commitMessage))
+
+	return "I" + hex.EncodeToString(h.Sum(nil))
+}

--- a/internal/scm/gerrit/gerrit_test.go
+++ b/internal/scm/gerrit/gerrit_test.go
@@ -43,19 +43,18 @@ var projects = &map[string]gogerrit.ProjectInfo{
 
 func getChangesForQuery(query string) (*[]gogerrit.ChangeInfo, *gogerrit.Response, error) {
 	var data = map[string][]gogerrit.ChangeInfo{
-		"project:repo-active+footer:MultiGitter-Branch=feature+is:open": {
+		"footer:MultiGitter-Branch=feature+project:repo-active+is:open": {
 			{Project: "repo-active", ChangeID: "I123", Branch: "feature", Number: 1000, Status: "NEW"},
 		},
-		"project:repo-active+footer:MultiGitter-Branch=feature": {
+		"footer:MultiGitter-Branch=feature": {
 			{Project: "repo-active", ChangeID: "I123", Branch: "feature", Number: 1000, Status: "NEW"},
 			{Project: "repo-active", ChangeID: "I000", Branch: "feature", Number: 1001, Status: "ABANDONED"},
 			{Project: "repo-active", ChangeID: "I644", Branch: "feature", Number: 1002, Submittable: true},
-		},
-		"project:another-repo-active+footer:MultiGitter-Branch=feature+is:open": {},
-		"project:another-repo-active+footer:MultiGitter-Branch=feature": {
 			{Project: "another-repo-active", ChangeID: "I666", Branch: "feature", Number: 1003, Status: "MERGED"},
+			{Project: "name-that-do-not-match", ChangeID: "I000", Branch: "feature", Number: 1004, Submittable: true},
 		},
-		"project:read-only+footer:MultiGitter-Branch=feature+is:open": {
+		"footer:MultiGitter-Branch=feature+project:another-repo-active+is:open": {},
+		"footer:MultiGitter-Branch=feature+project:read-only+is:open": {
 			{Project: "read-only", ChangeID: "I456", Branch: "feature", Number: 1004, Status: "NEW"},
 			{Project: "read-only", ChangeID: "I789", Branch: "feature", Number: 1004, Status: "NEW"},
 		},

--- a/internal/scm/gerrit/gerrit_test.go
+++ b/internal/scm/gerrit/gerrit_test.go
@@ -1,0 +1,350 @@
+package gerrit
+
+import (
+	gogerrit "github.com/andygrunwald/go-gerrit"
+	"github.com/lindell/multi-gitter/internal/scm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+type goGerritClientMock struct {
+	ListProjectsFunc  func(ctx context.Context, opt *gogerrit.ProjectOptions) (*map[string]gogerrit.ProjectInfo, *gogerrit.Response, error)
+	QueryChangesFunc  func(ctx context.Context, opt *gogerrit.QueryChangeOptions) (*[]gogerrit.ChangeInfo, *gogerrit.Response, error)
+	AbandonChangeFunc func(ctx context.Context, changeID string, input *gogerrit.AbandonInput) (*gogerrit.ChangeInfo, *gogerrit.Response, error)
+	SubmitChangeFunc  func(ctx context.Context, changeID string, input *gogerrit.SubmitInput) (*gogerrit.ChangeInfo, *gogerrit.Response, error)
+}
+
+func (gcm goGerritClientMock) ListProjects(ctx context.Context, opt *gogerrit.ProjectOptions) (*map[string]gogerrit.ProjectInfo, *gogerrit.Response, error) {
+	return gcm.ListProjectsFunc(ctx, opt)
+}
+
+func (gcm goGerritClientMock) QueryChanges(ctx context.Context, opt *gogerrit.QueryChangeOptions) (*[]gogerrit.ChangeInfo, *gogerrit.Response, error) {
+	return gcm.QueryChangesFunc(ctx, opt)
+}
+
+func (gcm goGerritClientMock) AbandonChange(ctx context.Context, changeID string, input *gogerrit.AbandonInput) (*gogerrit.ChangeInfo, *gogerrit.Response, error) {
+	return gcm.AbandonChangeFunc(ctx, changeID, input)
+}
+
+func (gcm goGerritClientMock) SubmitChange(ctx context.Context, changeID string, input *gogerrit.SubmitInput) (*gogerrit.ChangeInfo, *gogerrit.Response, error) {
+	return gcm.SubmitChangeFunc(ctx, changeID, input)
+}
+
+var projects = &map[string]gogerrit.ProjectInfo{
+	"repo-active":         {State: "ACTIVE"},
+	"repo-read-only":      {State: "READ_ONLY"},
+	"another-repo-active": {State: "ACTIVE"},
+}
+
+func getChangesForQuery(query string) (*[]gogerrit.ChangeInfo, *gogerrit.Response, error) {
+	var data = map[string][]gogerrit.ChangeInfo{
+		"project:repo-active+footer:MultiGitter-Branch=feature+is:open": {
+			{Project: "repo-active", ChangeID: "I123", Branch: "feature", Number: 1000, Status: "NEW"},
+		},
+		"project:repo-active+footer:MultiGitter-Branch=feature": {
+			{Project: "repo-active", ChangeID: "I123", Branch: "feature", Number: 1000, Status: "NEW"},
+			{Project: "repo-active", ChangeID: "I000", Branch: "feature", Number: 1001, Status: "ABANDONED"},
+			{Project: "repo-active", ChangeID: "I644", Branch: "feature", Number: 1002, Submittable: true},
+		},
+		"project:another-repo-active+footer:MultiGitter-Branch=feature+is:open": {},
+		"project:another-repo-active+footer:MultiGitter-Branch=feature": {
+			{Project: "another-repo-active", ChangeID: "I666", Branch: "feature", Number: 1003, Status: "MERGED"},
+		},
+		"project:read-only+footer:MultiGitter-Branch=feature+is:open": {
+			{Project: "read-only", ChangeID: "I456", Branch: "feature", Number: 1004, Status: "NEW"},
+			{Project: "read-only", ChangeID: "I789", Branch: "feature", Number: 1004, Status: "NEW"},
+		},
+	}
+
+	if strings.Contains(query, "throw-error") {
+		return nil, nil, assert.AnError
+	} else {
+		if changes, ok := data[query]; ok {
+			return &changes, nil, nil
+		} else {
+			return &[]gogerrit.ChangeInfo{}, nil, nil
+		}
+	}
+}
+
+func TestGetRepositories(t *testing.T) {
+	g := &Gerrit{
+		client: goGerritClientMock{
+			ListProjectsFunc: func(_ context.Context, opt *gogerrit.ProjectOptions) (*map[string]gogerrit.ProjectInfo, *gogerrit.Response, error) {
+				// Ensure we inject repoSearch parameter correctly
+				require.Equal(t, "repo", opt.Regex)
+				return projects, nil, nil
+			},
+		},
+		baseUrl:    "https://gerrit.com",
+		username:   "admin",
+		token:      "token123",
+		repoSearch: "repo",
+	}
+
+	repos, err := g.GetRepositories(context.Background())
+	require.NoError(t, err)
+	require.Len(t, repos, 2)
+
+	expectedRepos := []struct {
+		name          string
+		defaultBranch string
+		cloneURL      string
+	}{
+		{"another-repo-active", "master", "https://admin:token123@gerrit.com/a/another-repo-active"},
+		{"repo-active", "master", "https://admin:token123@gerrit.com/a/repo-active"},
+	}
+	for idx, expectedRepo := range expectedRepos {
+		repo := repos[idx]
+		assert.Equal(t, expectedRepo.name, repo.FullName())
+		assert.Equal(t, expectedRepo.defaultBranch, repo.DefaultBranch())
+		assert.Equal(t, expectedRepo.cloneURL, repo.CloneURL())
+	}
+}
+
+func TestGetPullRequests(t *testing.T) {
+	g := &Gerrit{
+		client: goGerritClientMock{
+			ListProjectsFunc: func(_ context.Context, opt *gogerrit.ProjectOptions) (*map[string]gogerrit.ProjectInfo, *gogerrit.Response, error) {
+				require.Equal(t, "repo", opt.Regex)
+				return projects, nil, nil
+			},
+			QueryChangesFunc: func(_ context.Context, opt *gogerrit.QueryChangeOptions) (*[]gogerrit.ChangeInfo, *gogerrit.Response, error) {
+				return getChangesForQuery(opt.QueryOptions.Query[0])
+			},
+		},
+		baseUrl:    "https://gerrit.com",
+		username:   "admin",
+		token:      "token123",
+		repoSearch: "repo",
+	}
+	prs, err := g.GetPullRequests(context.Background(), "feature")
+	require.NoError(t, err)
+	require.Len(t, prs, 4)
+
+	expectedPRs := []struct {
+		project  string
+		changeId string
+		number   int
+		status   scm.PullRequestStatus
+	}{
+		{"another-repo-active", "I666", 1003, scm.PullRequestStatusMerged},
+		{"repo-active", "I123", 1000, scm.PullRequestStatusPending},
+		{"repo-active", "I000", 1001, scm.PullRequestStatusClosed},
+		{"repo-active", "I644", 1002, scm.PullRequestStatusSuccess},
+	}
+	for idx, expectedPR := range expectedPRs {
+		pr := prs[idx]
+		change := pr.(change)
+		assert.Equal(t, expectedPR.status, pr.Status())
+		assert.Equal(t, strconv.Itoa(change.number)+": "+change.project, pr.String())
+		assert.Equal(t, expectedPR.project, change.project)
+		assert.Equal(t, expectedPR.changeId, change.changeId)
+		assert.Equal(t, "https://gerrit.com/c/"+change.project+"/+/"+strconv.Itoa(change.number), change.URL())
+	}
+}
+
+func TestGetOpenPullRequest(t *testing.T) {
+	g := &Gerrit{
+		client: goGerritClientMock{
+			QueryChangesFunc: func(_ context.Context, opt *gogerrit.QueryChangeOptions) (*[]gogerrit.ChangeInfo, *gogerrit.Response, error) {
+				return getChangesForQuery(opt.QueryOptions.Query[0])
+			},
+		},
+	}
+	tests := []struct {
+		repository       string
+		expectedErr      bool
+		expectedChangeId string
+	}{
+		{"repo-active", false, "I123"},
+		{"another-repo-active", false, ""},
+		{"read-only", true, ""},
+	}
+	for _, test := range tests {
+		t.Run(test.repository, func(t *testing.T) {
+			repo := repository{name: test.repository}
+			pr, err := g.GetOpenPullRequest(context.Background(), repo, "feature")
+
+			if test.expectedErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "More than one open change for branch feature in project "+test.repository)
+			} else {
+				require.NoError(t, err)
+				if test.expectedChangeId == "" {
+					require.Nil(t, pr)
+				} else {
+					require.NotNil(t, pr)
+					assert.Equal(t, test.expectedChangeId, pr.(change).changeId)
+				}
+			}
+		})
+	}
+}
+
+func TestCreatePullRequest(t *testing.T) {
+	g := &Gerrit{
+		client: goGerritClientMock{
+			QueryChangesFunc: func(_ context.Context, opt *gogerrit.QueryChangeOptions) (*[]gogerrit.ChangeInfo, *gogerrit.Response, error) {
+				return getChangesForQuery(opt.QueryOptions.Query[0])
+			},
+		},
+	}
+	repo := repository{name: "repo-active"}
+	pr, err := g.CreatePullRequest(context.Background(), repo, repo, scm.NewPullRequest{Head: "feature"})
+	require.NoError(t, err)
+	require.NotNil(t, pr)
+	assert.Equal(t, "I123", pr.(change).changeId)
+
+	pr, err = g.CreatePullRequest(context.Background(), repo, repo, scm.NewPullRequest{Head: "unknown-feature"})
+	require.Error(t, err)
+}
+
+func TestUpdatePullRequest(t *testing.T) {
+	g := &Gerrit{
+		client: goGerritClientMock{
+			QueryChangesFunc: func(_ context.Context, opt *gogerrit.QueryChangeOptions) (*[]gogerrit.ChangeInfo, *gogerrit.Response, error) {
+				return getChangesForQuery(opt.QueryOptions.Query[0])
+			},
+		},
+	}
+	repo := repository{name: "repo-active"}
+	pr, err := g.UpdatePullRequest(context.Background(), repo, change{}, scm.NewPullRequest{Head: "feature"})
+	require.NoError(t, err)
+	require.NotNil(t, pr)
+	assert.Equal(t, "I123", pr.(change).changeId)
+
+	pr, err = g.UpdatePullRequest(context.Background(), repo, change{}, scm.NewPullRequest{Head: "unknown-feature"})
+	require.Error(t, err)
+}
+
+func TestRemoteReference(t *testing.T) {
+	g := &Gerrit{}
+
+	tests := []struct {
+		baseBranch      string
+		featureBranch   string
+		skipPullRequest bool
+		pushOnly        bool
+		expectedRef     string
+	}{
+		{"master", "feature", false, false, "refs/for/master"},
+		{"master", "feature", true, false, "refs/heads/feature"},
+		{"master", "feature", false, true, "refs/heads/feature"},
+		{"master", "feature", true, true, "refs/heads/feature"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.baseBranch+"_"+test.featureBranch, func(t *testing.T) {
+			ref := g.RemoteReference(test.baseBranch, test.featureBranch, test.skipPullRequest, test.pushOnly)
+			assert.Equal(t, test.expectedRef, ref)
+		})
+	}
+}
+
+func TestFeatureBranchExist(t *testing.T) {
+	g := &Gerrit{
+		client: goGerritClientMock{
+			QueryChangesFunc: func(_ context.Context, opt *gogerrit.QueryChangeOptions) (*[]gogerrit.ChangeInfo, *gogerrit.Response, error) {
+				return getChangesForQuery(opt.QueryOptions.Query[0])
+			},
+		},
+	}
+
+	tests := []struct {
+		branchName string
+		expected   bool
+	}{
+		{"feature", true},
+		{"new-feature", false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.branchName, func(t *testing.T) {
+			repo := repository{name: "repo-active"}
+			exist, err := g.FeatureBranchExist(context.Background(), repo, test.branchName)
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, exist)
+		})
+	}
+}
+
+func TestEnhanceCommit(t *testing.T) {
+	g := &Gerrit{
+		client: goGerritClientMock{
+			QueryChangesFunc: func(_ context.Context, opt *gogerrit.QueryChangeOptions) (*[]gogerrit.ChangeInfo, *gogerrit.Response, error) {
+				return getChangesForQuery(opt.QueryOptions.Query[0])
+			},
+		},
+	}
+
+	tests := []struct {
+		branchName    string
+		expectedErr   bool
+		changeIdRegex string
+	}{
+		{"feature", false, "I123"},
+		{"new-feature", false, "I[0-9a-f]{40}"},
+		{"feature-that-throw-error", true, ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.branchName, func(t *testing.T) {
+			repo := repository{name: "repo-active"}
+			msg, err := g.EnhanceCommit(context.Background(), repo, test.branchName, "dummy commit message")
+			if test.expectedErr {
+				require.Error(t, err)
+				assert.Equal(t, "dummy commit message", msg)
+			} else {
+				require.NoError(t, err)
+				assert.Regexp(t, regexp.MustCompile(
+					"dummy commit message\n\nMultiGitter-Branch: "+test.branchName+"\nChange-Id: "+test.changeIdRegex), msg)
+			}
+		})
+	}
+}
+
+func TestMergePullRequest(t *testing.T) {
+	g := &Gerrit{
+		client: goGerritClientMock{
+			SubmitChangeFunc: func(_ context.Context, changeID string, input *gogerrit.SubmitInput) (*gogerrit.ChangeInfo, *gogerrit.Response, error) {
+				// Ensure correct id is used when a change is submitted
+				require.Equal(t, "repo-active~master~Icc717a31a47beb9b5d9aeb8a1d374883afe89030", changeID)
+				return &gogerrit.ChangeInfo{}, nil, nil
+			},
+		},
+	}
+	pr := change{
+		id:       "repo-active~master~Icc717a31a47beb9b5d9aeb8a1d374883afe89030",
+		project:  "repo-active",
+		branch:   "master",
+		changeId: "Icc717a31a47beb9b5d9aeb8a1d374883afe89030",
+	}
+	err := g.MergePullRequest(context.Background(), pr)
+	require.NoError(t, err)
+}
+
+func TestClosePullRequest(t *testing.T) {
+	g := &Gerrit{
+		client: goGerritClientMock{
+			AbandonChangeFunc: func(ctx context.Context, changeID string, input *gogerrit.AbandonInput) (*gogerrit.ChangeInfo, *gogerrit.Response, error) {
+				// Ensure correct id is used when a change is abandoned
+				require.Equal(t, "repo-active~master~Icc717a31a47beb9b5d9aeb8a1d374883afe89030", changeID)
+				return &gogerrit.ChangeInfo{}, nil, nil
+			},
+		},
+	}
+	pr := change{
+		id:       "repo-active~master~Icc717a31a47beb9b5d9aeb8a1d374883afe89030",
+		project:  "repo-active",
+		branch:   "master",
+		changeId: "Icc717a31a47beb9b5d9aeb8a1d374883afe89030",
+	}
+	err := g.ClosePullRequest(context.Background(), pr)
+	require.NoError(t, err)
+}

--- a/internal/scm/gerrit/gogerrit_client.go
+++ b/internal/scm/gerrit/gogerrit_client.go
@@ -1,0 +1,34 @@
+package gerrit
+
+import (
+	gogerrit "github.com/andygrunwald/go-gerrit"
+	"golang.org/x/net/context"
+)
+
+// GoGerritClient define Methods used by gerrit implementation, and facilitate unit testing with mock
+type GoGerritClient interface {
+	ListProjects(ctx context.Context, opt *gogerrit.ProjectOptions) (*map[string]gogerrit.ProjectInfo, *gogerrit.Response, error)
+	QueryChanges(ctx context.Context, opt *gogerrit.QueryChangeOptions) (*[]gogerrit.ChangeInfo, *gogerrit.Response, error)
+	AbandonChange(ctx context.Context, changeID string, input *gogerrit.AbandonInput) (*gogerrit.ChangeInfo, *gogerrit.Response, error)
+	SubmitChange(ctx context.Context, changeID string, input *gogerrit.SubmitInput) (*gogerrit.ChangeInfo, *gogerrit.Response, error)
+}
+
+type goGerritClient struct {
+	client *gogerrit.Client
+}
+
+func (ggc goGerritClient) ListProjects(ctx context.Context, opt *gogerrit.ProjectOptions) (*map[string]gogerrit.ProjectInfo, *gogerrit.Response, error) {
+	return ggc.client.Projects.ListProjects(ctx, opt)
+}
+
+func (ggc goGerritClient) QueryChanges(ctx context.Context, opt *gogerrit.QueryChangeOptions) (*[]gogerrit.ChangeInfo, *gogerrit.Response, error) {
+	return ggc.client.Changes.QueryChanges(ctx, opt)
+}
+
+func (ggc goGerritClient) AbandonChange(ctx context.Context, changeID string, input *gogerrit.AbandonInput) (*gogerrit.ChangeInfo, *gogerrit.Response, error) {
+	return ggc.client.Changes.AbandonChange(ctx, changeID, input)
+}
+
+func (ggc goGerritClient) SubmitChange(ctx context.Context, changeID string, input *gogerrit.SubmitInput) (*gogerrit.ChangeInfo, *gogerrit.Response, error) {
+	return ggc.client.Changes.SubmitChange(ctx, changeID, input)
+}

--- a/internal/scm/gerrit/gogerrit_client.go
+++ b/internal/scm/gerrit/gogerrit_client.go
@@ -5,16 +5,18 @@ import (
 	"golang.org/x/net/context"
 )
 
-// GoGerritClient define Methods used by gerrit implementation, and facilitate unit testing with mock
+// The gogerrit.Client struct encapsulates sub-structs for each API endpoint.
+// Defining our own interface allows us to flatten the client structure
+// by exposing only the necessary methods, which simplifies mocking in tests.
+type goGerritClient struct {
+	client *gogerrit.Client
+}
+
 type GoGerritClient interface {
 	ListProjects(ctx context.Context, opt *gogerrit.ProjectOptions) (*map[string]gogerrit.ProjectInfo, *gogerrit.Response, error)
 	QueryChanges(ctx context.Context, opt *gogerrit.QueryChangeOptions) (*[]gogerrit.ChangeInfo, *gogerrit.Response, error)
 	AbandonChange(ctx context.Context, changeID string, input *gogerrit.AbandonInput) (*gogerrit.ChangeInfo, *gogerrit.Response, error)
 	SubmitChange(ctx context.Context, changeID string, input *gogerrit.SubmitInput) (*gogerrit.ChangeInfo, *gogerrit.Response, error)
-}
-
-type goGerritClient struct {
-	client *gogerrit.Client
 }
 
 func (ggc goGerritClient) ListProjects(ctx context.Context, opt *gogerrit.ProjectOptions) (*map[string]gogerrit.ProjectInfo, *gogerrit.Response, error) {

--- a/internal/scm/gerrit/repository.go
+++ b/internal/scm/gerrit/repository.go
@@ -1,0 +1,19 @@
+package gerrit
+
+type repository struct {
+	url           string
+	name          string
+	defaultBranch string
+}
+
+func (r repository) CloneURL() string {
+	return r.url
+}
+
+func (r repository) DefaultBranch() string {
+	return r.defaultBranch
+}
+
+func (r repository) FullName() string {
+	return r.name
+}

--- a/tests/repo_helper_test.go
+++ b/tests/repo_helper_test.go
@@ -178,3 +178,18 @@ func fileExist(t *testing.T, basePath string, fn string) bool {
 func normalizePath(path string) string {
 	return strings.ReplaceAll(filepath.ToSlash(path), " ", "\\ ")
 }
+
+func getCommitMessage(t *testing.T, path string, referenceName string) (string, error) {
+	repo, err := git.PlainOpen(path)
+	assert.NoError(t, err)
+
+	reference, err := repo.Reference(plumbing.ReferenceName(referenceName), false)
+	if err != nil {
+		return "", err
+	}
+
+	commit, err := repo.CommitObject(reference.Hash())
+	assert.NoError(t, err)
+
+	return commit.Message, nil
+}

--- a/tests/table_test.go
+++ b/tests/table_test.go
@@ -3,7 +3,6 @@ package tests
 import (
 	"bytes"
 	"fmt"
-	"github.com/lindell/multi-gitter/internal/multigitter"
 	"io"
 	"os"
 	"path/filepath"
@@ -13,6 +12,7 @@ import (
 	"time"
 
 	"github.com/lindell/multi-gitter/cmd"
+	"github.com/lindell/multi-gitter/internal/multigitter"
 	"github.com/lindell/multi-gitter/internal/scm"
 	"github.com/lindell/multi-gitter/tests/vcmock"
 

--- a/tests/vcmock/gerritmock.go
+++ b/tests/vcmock/gerritmock.go
@@ -1,0 +1,65 @@
+package vcmock
+
+import (
+	"github.com/lindell/multi-gitter/internal/scm"
+	"golang.org/x/net/context"
+)
+
+type GerritVersionController struct {
+	VC VersionController
+}
+
+// Here we are mocking functions only used for Gerrit VersionController
+
+func (gm *GerritVersionController) EnhanceCommit(_ context.Context, _ scm.Repository, branchName string, commitMessage string) (string, error) {
+	message := commitMessage
+	message = message + "\n\n" + "Mocked-Footer" + ": " + branchName
+	return message, nil
+}
+
+func (gm *GerritVersionController) RemoteReference(_ string, featureBranch string, _ bool, _ bool) string {
+	return "refs/heads/mocked-" + featureBranch
+}
+
+func (gm *GerritVersionController) FeatureBranchExist(ctx context.Context, repo scm.Repository, branchName string) (bool, error) {
+	pr, err := gm.VC.GetOpenPullRequest(ctx, repo, branchName)
+	return pr != nil, err
+}
+
+// Below we are just calling the mock VersionController
+
+func (gm *GerritVersionController) ForkRepository(ctx context.Context, repo scm.Repository, newOwner string) (scm.Repository, error) {
+	return gm.VC.ForkRepository(ctx, repo, newOwner)
+}
+
+func (gm *GerritVersionController) GetRepositories(ctx context.Context) ([]scm.Repository, error) {
+	return gm.VC.GetRepositories(ctx)
+}
+
+func (gm *GerritVersionController) CreatePullRequest(ctx context.Context, repo scm.Repository, prRepo scm.Repository, newPR scm.NewPullRequest) (scm.PullRequest, error) {
+	return gm.VC.CreatePullRequest(ctx, repo, prRepo, newPR)
+}
+
+func (gm *GerritVersionController) UpdatePullRequest(ctx context.Context, repo scm.Repository, pullReq scm.PullRequest, updatedPR scm.NewPullRequest) (scm.PullRequest, error) {
+	return gm.VC.UpdatePullRequest(ctx, repo, pullReq, updatedPR)
+}
+
+func (gm *GerritVersionController) GetPullRequests(ctx context.Context, branchName string) ([]scm.PullRequest, error) {
+	return gm.VC.GetPullRequests(ctx, branchName)
+}
+
+func (gm *GerritVersionController) GetOpenPullRequest(ctx context.Context, repo scm.Repository, branchName string) (scm.PullRequest, error) {
+	return gm.VC.GetOpenPullRequest(ctx, repo, branchName)
+}
+
+func (gm *GerritVersionController) MergePullRequest(ctx context.Context, pr scm.PullRequest) error {
+	return gm.VC.MergePullRequest(ctx, pr)
+}
+
+func (gm *GerritVersionController) ClosePullRequest(ctx context.Context, pr scm.PullRequest) error {
+	return gm.VC.ClosePullRequest(ctx, pr)
+}
+
+func (gm *GerritVersionController) Clean() {
+	gm.VC.Clean()
+}


### PR DESCRIPTION
Done

- Init implementation of `VersionController` interface with dummy behaviour (TL;DR : `return nil, errors.New("implement me")`)
- Integrate `go-gerrit` lib
- Allow connection with Gerrit API (reuse username, base-url, token parameters)
- Implement `GetRepositories` with search based on Regex (cf https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#list-projects)
- Implement `GetPullRequests` and `GetPullRequests`
- Implement `MergePullRequest` and `ClosePullRequest`
- Minimal implementation for `CreatePullRequest` and `UpdatePullRequest`, just to be able to return an `scm.PullRequest` object

Will not be implemented 
- ForkRepository 


